### PR TITLE
Fix helper comment of dart res.send() and res.json()

### DIFF
--- a/dart-2.12/lib/main.dart
+++ b/dart-2.12/lib/main.dart
@@ -5,8 +5,8 @@
     'variables' - object with function variables
 
   'res' variable has:
-    'send(text, status)' - function to return text response. Status code defaults to 200
-    'json(obj, status)' - function to return JSON response. Status code defaults to 200
+    'send(text, status: status)' - function to return text response. Status code defaults to 200
+    'json(obj, status: status)' - function to return JSON response. Status code defaults to 200
   
   If an error is thrown, a response with code 500 will be returned.
 */

--- a/dart-2.13/lib/main.dart
+++ b/dart-2.13/lib/main.dart
@@ -5,8 +5,8 @@
     'variables' - object with function variables
 
   'res' variable has:
-    'send(text, status)' - function to return text response. Status code defaults to 200
-    'json(obj, status)' - function to return JSON response. Status code defaults to 200
+    'send(text, status: status)' - function to return text response. Status code defaults to 200
+    'json(obj, status: status)' - function to return JSON response. Status code defaults to 200
   
   If an error is thrown, a response with code 500 will be returned.
 */

--- a/dart-2.14/lib/main.dart
+++ b/dart-2.14/lib/main.dart
@@ -7,8 +7,8 @@ import 'package:dart_appwrite/dart_appwrite.dart';
     'variables' - object with function variables
 
   'res' variable has:
-    'send(text, status)' - function to return text response. Status code defaults to 200
-    'json(obj, status)' - function to return JSON response. Status code defaults to 200
+    'send(text, status: status)' - function to return text response. Status code defaults to 200
+    'json(obj, status: status)' - function to return JSON response. Status code defaults to 200
   
   If an error is thrown, a response with code 500 will be returned.
 */

--- a/dart-2.15/lib/main.dart
+++ b/dart-2.15/lib/main.dart
@@ -7,8 +7,8 @@ import 'package:dart_appwrite/dart_appwrite.dart';
     'variables' - object with function variables
 
   'res' variable has:
-    'send(text, status)' - function to return text response. Status code defaults to 200
-    'json(obj, status)' - function to return JSON response. Status code defaults to 200
+    'send(text, status: status)' - function to return text response. Status code defaults to 200
+    'json(obj, status: status)' - function to return JSON response. Status code defaults to 200
   
   If an error is thrown, a response with code 500 will be returned.
 */

--- a/dart-2.16/lib/main.dart
+++ b/dart-2.16/lib/main.dart
@@ -7,8 +7,8 @@ import 'package:dart_appwrite/dart_appwrite.dart';
     'variables' - object with function variables
 
   'res' variable has:
-    'send(text, status)' - function to return text response. Status code defaults to 200
-    'json(obj, status)' - function to return JSON response. Status code defaults to 200
+    'send(text, status: status)' - function to return text response. Status code defaults to 200
+    'json(obj, status: status)' - function to return JSON response. Status code defaults to 200
   
   If an error is thrown, a response with code 500 will be returned.
 */

--- a/dart-2.17/lib/main.dart
+++ b/dart-2.17/lib/main.dart
@@ -7,8 +7,8 @@ import 'package:dart_appwrite/dart_appwrite.dart';
     'variables' - object with function variables
 
   'res' variable has:
-    'send(text, status)' - function to return text response. Status code defaults to 200
-    'json(obj, status)' - function to return JSON response. Status code defaults to 200
+    'send(text, status: status)' - function to return text response. Status code defaults to 200
+    'json(obj, status: status)' - function to return JSON response. Status code defaults to 200
   
   If an error is thrown, a response with code 500 will be returned.
 */


### PR DESCRIPTION
## What does this PR do?

Because `status` is optional, the correct syntax for how to pass the status is like this:

```dart
res.json({"attr": "value"}, status: 200);
```

This change updates the comment to help make that clear, especially since there is no type on the res parameter.

## Test Plan

None

## Related PRs and Issues

* 

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes