### PR TITLE
Update deps.gradle

### DIFF
--- a/java-17.0/deps.gradle
+++ b/java-17.0/deps.gradle
@@ -1,3 +1,4 @@
 dependencies {
     implementation 'io.appwrite:sdk-for-kotlin:1.0.0'
+    implementation 'org.apache.logging.log4j:log4j:2.19.0'
 }


### PR DESCRIPTION
Added class to correct syntax error. all .java class files must have at least one public class.

<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?
Added Apache Log4j Gradle dependency for implementing log4j in index.java
(Provide a description of what this PR does.)
This PR is for doing a bugfix which had no class in the java file.

## Test Plan

(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work.)

## Related PRs and Issues
Update Index.java #43
(If this PR is related to any other PR or resolves any issue or related to any issue link all related PR and issues here.)

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
yes
(Write your answer here.)