### PR TITLE
Fix incorrect Databases class

### DIFF
--- a/python-3.10/src/index.py
+++ b/python-3.10/src/index.py
@@ -30,7 +30,7 @@ def main(req, res):
   # You can remove services you don't use
   account = Account(client)
   avatars = Avatars(client)
-  database = Database(client)
+  database = Databases(client)
   functions = Functions(client)
   health = Health(client)
   locale = Locale(client)


### PR DESCRIPTION
## What does this PR do?

Python 3.10 had `Database(client)` instead of `Databases(client)`.

## Test Plan

None

## Related PRs and Issues

None

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes