### PR TITLE
Bump Kotlin SDK version in java and kotlin starters

### DIFF
--- a/java-11.0/deps.gradle
+++ b/java-11.0/deps.gradle
@@ -1,3 +1,3 @@
 dependencies {
-    implementation 'io.appwrite:sdk-for-kotlin:1.0.0'
+    implementation 'io.appwrite:sdk-for-kotlin:1.2.0'
 }

--- a/java-17.0/deps.gradle
+++ b/java-17.0/deps.gradle
@@ -1,3 +1,3 @@
 dependencies {
-    implementation 'io.appwrite:sdk-for-kotlin:1.0.0'
+    implementation 'io.appwrite:sdk-for-kotlin:1.2.0'
 }

--- a/java-18.0/deps.gradle
+++ b/java-18.0/deps.gradle
@@ -1,3 +1,3 @@
 dependencies {
-    implementation 'io.appwrite:sdk-for-kotlin:1.0.0'
+    implementation 'io.appwrite:sdk-for-kotlin:1.2.0'
 }

--- a/java-8.0/deps.gradle
+++ b/java-8.0/deps.gradle
@@ -1,3 +1,3 @@
 dependencies {
-    implementation 'io.appwrite:sdk-for-kotlin:1.0.0'
+    implementation 'io.appwrite:sdk-for-kotlin:1.2.0'
 }

--- a/kotlin-1.6/deps.gradle
+++ b/kotlin-1.6/deps.gradle
@@ -1,3 +1,3 @@
 dependencies {
-    implementation 'io.appwrite:sdk-for-kotlin:1.0.0'
+    implementation 'io.appwrite:sdk-for-kotlin:1.2.0'
 }


### PR DESCRIPTION
## What does this PR do?

Our function docs and examples used something in v1.2.0 of the SDK so the starters should use 1.2.0 so that they work.

## Test Plan

Manually tested.

Successful build:

<img width="829" alt="image" src="https://user-images.githubusercontent.com/1477010/217913068-50bfdd54-2a1f-4a6f-99c4-b087e7fb086e.png">

Successful start:

<img width="828" alt="image" src="https://user-images.githubusercontent.com/1477010/217913148-14c62a66-1f24-4a72-8858-08d5c7a03cdc.png">

Successful execution:

<img width="826" alt="image" src="https://user-images.githubusercontent.com/1477010/217913211-25082389-89c3-4834-a1e6-cc0f37b40015.png">

## Related PRs and Issues

None

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes