### PR TITLE
Fix deno import links

### DIFF
--- a/deno-1.12/src/deps.ts
+++ b/deno-1.12/src/deps.ts
@@ -1,1 +1,1 @@
-export * as sdk from "https://deno.land/x/appwrite@6.0.0/mod.ts";
+export * as sdk from "https://deno.land/x/appwrite/mod.ts";

--- a/deno-1.12/src/deps.ts
+++ b/deno-1.12/src/deps.ts
@@ -1,1 +1,1 @@
-export * as sdk from "https://deno.land/x/appwrite/mod.ts";
+export * as sdk from "https://deno.land/x/appwrite@7.0.0/mod.ts";

--- a/deno-1.13/src/deps.ts
+++ b/deno-1.13/src/deps.ts
@@ -1,1 +1,1 @@
-export * as sdk from "https://deno.land/x/appwrite@6.0.0/mod.ts";
+export * as sdk from "https://deno.land/x/appwrite@7.0.0/mod.ts";

--- a/deno-1.14/src/deps.ts
+++ b/deno-1.14/src/deps.ts
@@ -1,1 +1,1 @@
-export * as sdk from "https://deno.land/x/appwrite@6.0.0/mod.ts";
+export * as sdk from "https://deno.land/x/appwrite/mod.ts";

--- a/deno-1.14/src/deps.ts
+++ b/deno-1.14/src/deps.ts
@@ -1,1 +1,1 @@
-export * as sdk from "https://deno.land/x/appwrite/mod.ts";
+export * as sdk from "https://deno.land/x/appwrite@7.0.0/mod.ts";

--- a/deno-1.21/src/deps.ts
+++ b/deno-1.21/src/deps.ts
@@ -1,1 +1,1 @@
-export * as sdk from "https://deno.land/x/appwrite@6.0.0/mod.ts";
+export * as sdk from "https://deno.land/x/appwrite/mod.ts";

--- a/deno-1.21/src/deps.ts
+++ b/deno-1.21/src/deps.ts
@@ -1,1 +1,1 @@
-export * as sdk from "https://deno.land/x/appwrite/mod.ts";
+export * as sdk from "https://deno.land/x/appwrite@7.0.0/mod.ts";

--- a/deno-1.24/src/deps.ts
+++ b/deno-1.24/src/deps.ts
@@ -1,1 +1,1 @@
-export * as sdk from "https://deno.land/x/appwrite@6.0.0/mod.ts";
+export * as sdk from "https://deno.land/x/appwrite/mod.ts";

--- a/deno-1.24/src/deps.ts
+++ b/deno-1.24/src/deps.ts
@@ -1,1 +1,1 @@
-export * as sdk from "https://deno.land/x/appwrite/mod.ts";
+export * as sdk from "https://deno.land/x/appwrite@7.0.0/mod.ts";


### PR DESCRIPTION
## What does this PR do?

Fix deno runtime import links.

## Test Plan

- Run appwrite cli command `appwrite init function` and choose deno runtime.
- Go into `function/src/deps.ts` and change `https://deno.land/x/appwrite@6.0.0/mod.ts` to `https://deno.land/x/appwrite/mod.ts`.
- Deploy function
- Build succeeds now 


## Related PRs and Issues

Fix for #52

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes.